### PR TITLE
Temporary fix for edge-to-edge display problem on Android 15 (API 35)

### DIFF
--- a/src/main/res/values-v35/styles.xml
+++ b/src/main/res/values-v35/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+
+</resources>


### PR DESCRIPTION
* Related Issue: https://github.com/poretsky/TuningFork/issues/3

* Uses `android:windowOptOutEdgeToEdgeEnforcement` attribute in a separate `values-v35/styles.xml` (See [attribute at Android Developers Reference](https://developer.android.com/reference/android/R.attr#windowOptOutEdgeToEdgeEnforcement))
  * As noted on that page, "this attribute will be deprecated and disabled in a future SDK level", so a permanent fix should be planned.


![TuningFork_A15_after_fix](https://github.com/user-attachments/assets/fa265e08-785d-492b-899b-2460d6b1c810)
